### PR TITLE
feat: use new contract ID style

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,7 +1,7 @@
 # paths = ["/path/to/override"] # path dependency overrides
 
 [alias] # command aliases
-install_soroban = "install --git https://github.com/ahalabs/soroban-tools --rev 9c7fe217d0b850728232050ae3373a6f37f91f9a --root ./target soroban-cli --debug"
+install_soroban = "install --git https://github.com/ahalabs/soroban-tools --rev 931fe1c9305135b4573a16e41ca52619e83c531e --root ./target soroban-cli --debug"
 # c = "check"
 # t = "test"
 # r = "run"

--- a/package-lock.json
+++ b/package-lock.json
@@ -854,6 +854,11 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
     },
+    "node_modules/@juanelas/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@juanelas/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-mr2pfRQpWap0Uq4tlrCgp3W+Yjx1/Bpq4QJsYeAQUh1mExgyQvXz7xUhmYT2HcLLspuAL5dpnos8P2QhaCSXsQ=="
+    },
     "node_modules/@ljharb/has-package-exports-patterns": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/@ljharb/has-package-exports-patterns/-/has-package-exports-patterns-0.0.2.tgz",
@@ -1048,8 +1053,9 @@
       "resolved": "file:target/js-clients/abundance",
       "dependencies": {
         "@stellar/freighter-api": "1.4.0",
+        "bigint-conversion": "2.4.1",
         "buffer": "6.0.3",
-        "soroban-client": "0.7.2"
+        "soroban-client": "0.8.0"
       }
     },
     "node_modules/acorn": {
@@ -1311,6 +1317,14 @@
       "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/bigint-conversion": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/bigint-conversion/-/bigint-conversion-2.4.1.tgz",
+      "integrity": "sha512-/DTRevseMZoqN4KLkN5BryOiom0KbwYajiXG5Vo+ZcEPAO0WBZyZoYyDZSgfeq/v/oegLo9bjdndDBlExvAhBQ==",
+      "dependencies": {
+        "@juanelas/base64": "^1.1.2"
       }
     },
     "node_modules/bignumber.js": {
@@ -5017,9 +5031,9 @@
       }
     },
     "node_modules/sodium-native": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-4.0.3.tgz",
-      "integrity": "sha512-0zOjNag+0gIRe56O1TkTfltT+b+JhOpGV6u69MVoKy+BTH95viPPJ0exHHnmgRliWKDGyYsyNeyBamfcU7ZlgQ==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-4.0.4.tgz",
+      "integrity": "sha512-faqOKw4WQKK7r/ybn6Lqo1F9+L5T6NlBJJYvpxbZPetpWylUVqz449mvlwIBKBqxEHbWakWuOlUt8J3Qpc4sWw==",
       "hasInstallScript": true,
       "optional": true,
       "dependencies": {
@@ -5027,18 +5041,19 @@
       }
     },
     "node_modules/soroban-client": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/soroban-client/-/soroban-client-0.7.2.tgz",
-      "integrity": "sha512-RCYFIrPkhLHogMQZRUDWFXG5i897BL+YjM1XQgIAim/MwwQiyoaxZEipzQU0z78UXIjCxMIUWiE203otdrGIbw==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/soroban-client/-/soroban-client-0.8.0.tgz",
+      "integrity": "sha512-INc9W6uOZfHaa/n747jN+r6V2FvpmmFNoh5Ki1HbQbcKqiSo6yY/d1a4//AbMyzDs8WXeNTJOA2EYJnqcexdiw==",
       "dependencies": {
         "axios": "^1.4.0",
         "bignumber.js": "^9.1.1",
+        "buffer": "^6.0.3",
         "detect-node": "^2.0.4",
         "es6-promise": "^4.2.4",
         "eventsource": "^2.0.2",
         "lodash": "^4.17.21",
         "randombytes": "^2.1.0",
-        "stellar-base": "^9.0.0-soroban.1",
+        "stellar-base": "^9.0.0-soroban.3",
         "toml": "^3.0.0",
         "urijs": "^1.19.1"
       }

--- a/src/js/render.ts
+++ b/src/js/render.ts
@@ -13,6 +13,8 @@ export default async function render() {
     window.freighterNetwork?.network.toUpperCase() === 'FUTURENET'
 
   if (allReady) {
+    // @ts-expect-error
+    window.decimals = decimals
     // ensure that the symbol matches the expected (mostly to demo the symbol() function)
     if (!tokenSymbol) {
       tokenSymbol = (await symbol()).toString()


### PR DESCRIPTION
- redeploy contract, latest CLI now gives new `C…`-style ID
- using that new ID doesn't actually work with the version of soroban-env used by Futurenet, it would seem